### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,8 +5,8 @@
 ########################################
 # Datatypes (KEYWORD1)
 ########################################
-  
-ADB922S	KEYWORD1    
+
+ADB922S	KEYWORD1 
 KGPS	KEYWORD1
 
 TASK_LIST	KEYWORD1
@@ -102,14 +102,14 @@ PORT	KEYWORD2
 ########################################
 # Constants (LITERAL1)
 ########################################
-BPS_9600		LITERAL1
-BPS_19200		LITERAL1
-BPS_57600		LITERAL1
-BPS_115200		LITERAL1
-DR2		LITERAL1
-DR3		LITERAL1
-DR4		LITERAL1
-DR5		LITERAL1
+BPS_9600	LITERAL1
+BPS_19200	LITERAL1
+BPS_57600	LITERAL1
+BPS_115200	LITERAL1
+DR2	LITERAL1
+DR3	LITERAL1
+DR4	LITERAL1
+DR5	LITERAL1
 
-KashiwaGeeks		LITERAL1
+KashiwaGeeks	LITERAL1
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -42,7 +42,7 @@ getNbGw	KEYWORD2
 wakeup	KEYWORD2
 sleep	KEYWORD2
 wakeup	KEYWORD2
-reset	KEYWORK2
+reset	KEYWORD2
 start	KEYWORD2
 int0D2	KEYWORD2
 int1D3	KEYWORD2
@@ -98,7 +98,7 @@ EnableInt1	KEYWORD2
 SetUTC	KEYWORD2
 
 TASK	KEYWORD2
-PORT	KEWWORD2
+PORT	KEYWORD2
 ########################################
 # Constants (LITERAL1)
 ########################################


### PR DESCRIPTION
- Correct invalid keywords.txt KEYWORD_TOKENTYPEs
- Use a single tab field separator

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

This is a repeat of https://github.com/ty4tw/KashiwaGeeks/pull/3, which seems to have been reverted.